### PR TITLE
Added unicode support

### DIFF
--- a/js2js.py
+++ b/js2js.py
@@ -12,12 +12,13 @@ import re
 import sys
 import glob
 import string
+import codecs
 
 
 def mine_js_file(js_pathname, po_filename):
 
     # Read data from the existing PO file
-    po_fd = open(po_filename, "r")
+    po_fd = codecs.open(po_filename, "r", "UTF-8")
     po_dict = {}
 
     # Build a translation dictionary from the PO file
@@ -35,9 +36,9 @@ def mine_js_file(js_pathname, po_filename):
 
     for path in js_files:
         basename = os.path.basename(path)
-        js_fd = open(path, "r")
+        js_fd = codecs.open(path, "r", "UTF-8")
 
-        output = open(path[0:-3] + '_.js', 'w')
+        output = codecs.open(path[0:-3] + '_.js', 'w', "UTF-8")
 
         for line in js_fd:
             tmp = line.split("_('")
@@ -90,9 +91,9 @@ def mine_js_file(js_pathname, po_filename):
 
     for path in json_files:
         basename = os.path.basename(path)
-        js_fd = open(path, "r")
+        js_fd = codecs.open(path, "r", "UTF-8")
 
-        output = open(path[0:-5] + '_.json', 'w')
+        output = codecs.open(path[0:-5] + '_.json', 'w', "UTF-8")
 
         for line in js_fd:
             tmp = line.split("_('")

--- a/js2pot.py
+++ b/js2pot.py
@@ -10,12 +10,13 @@ import re
 import sys
 import glob
 import string
+import codecs
 
 
 def mine_js_files(js_pathname, pot_filename):
 
     # Read data from the existing POT file
-    pot_fd = open(pot_filename, "r")
+    pot_fd = codecs.open(pot_filename, "r", "UTF-8")
     pot_list = []
 
     trans_note = []
@@ -66,7 +67,7 @@ def mine_js_files(js_pathname, pot_filename):
 
     for path in js_files:
         basename = os.path.basename(path)
-        js_fd = open(path, "r")
+        js_fd = codecs.open(path, "r", "UTF-8")
 
         count = 1
         for line in js_fd:
@@ -123,7 +124,7 @@ def mine_js_files(js_pathname, pot_filename):
 
     for path in rtp_files:
         basename = os.path.basename(path)
-        js_fd = open(path, "r")
+        js_fd = codecs.open(path, "r", "UTF-8")
 
         count = 1
         for line in js_fd:
@@ -175,7 +176,7 @@ def mine_js_files(js_pathname, pot_filename):
 
             count += 1
 
-    output = open(pot_filename + '_', 'w')
+    output = codecs.open(pot_filename + '_', 'w', "UTF-8")
     output.write(pot_header)
     
     for i in range(len(js_list)):

--- a/po2po.py
+++ b/po2po.py
@@ -9,12 +9,13 @@
 import os
 import re
 import sys
+import codecs
 
 
 def mine_from_po_to_po(oldfilename, newfilename, ignore_case):
-    oldfd = open(oldfilename, "r")
-    newfd = open(newfilename, "r")
-    output = open('tmp.po', "w")
+    oldfd = codecs.open(oldfilename, "r", "UTF-8")
+    newfd = codecs.open(newfilename, "r", "UTF-8")
+    output = codecs.open('tmp.po', "w", "UTF-8")
 
     olddict = {}
     for line in oldfd:

--- a/pot2po.py
+++ b/pot2po.py
@@ -10,12 +10,13 @@
 import os
 import re
 import sys
+import codecs
 
 
 def convert_pot_to_po(pot_filename, po_filename, trans_filename):
 
     # Read data from the existing POT file
-    pot_fd = open(pot_filename, 'r')
+    pot_fd = codecs.open(pot_filename, 'r', 'UTF-8')
     pot_list = []
 
     trans_note = []
@@ -47,7 +48,7 @@ def convert_pot_to_po(pot_filename, po_filename, trans_filename):
     if trans_filename == '':
         trans_dict = {}
     else:
-        trans_fd = open(trans_filename, 'r')
+        trans_fd = codecs.open(trans_filename, 'r', 'UTF-8')
 
         trans_dict = {}
 
@@ -63,7 +64,7 @@ def convert_pot_to_po(pot_filename, po_filename, trans_filename):
 
         trans_fd.close()
 
-    po_fd = open(po_filename, 'r')
+    po_fd = codecs.open(po_filename, 'r', 'UTF-8')
     po_dict = {}
     po_header = ''
 
@@ -123,7 +124,7 @@ def convert_pot_to_po(pot_filename, po_filename, trans_filename):
 
     po_fd.close()
 
-    output = open(po_filename + '_', 'w')
+    output = codecs.open(po_filename + '_', 'w', 'UTF-8')
     output.write(po_header)
 
     for i in range(len(pot_list)):

--- a/svg2svg.py
+++ b/svg2svg.py
@@ -10,12 +10,13 @@ import re
 import sys
 import glob
 import string
+import codecs
 
 
 def mine_svg_file(svg_filename, po_filename):
 
     # Read data from the existing PO file
-    po_fd = open(po_filename, "r")
+    po_fd = codecs.open(po_filename, "r", "UTF-8")
     po_dict = {}
 
     # Build a translation dictionary from the PO file
@@ -29,9 +30,9 @@ def mine_svg_file(svg_filename, po_filename):
     # Mine strings for l23n from the svg.
     svg_list = []
 
-    svg_fd = open(svg_filename, "r")
+    svg_fd = codecs.open(svg_filename, "r", "UTF-8")
     tmp = svg_filename.split('.');
-    output = open(tmp[0] + '_.svg', 'w')
+    output = codecs.open(tmp[0] + '_.svg', 'w', "UTF-8")
 
     count = 1
     for line in svg_fd:


### PR DESCRIPTION
Previously, when @pikurasa tried to use pot2po.py to convert a file with Japanese characters, he reported seeing "backslash[es] followed by a number" in place of the Japanese characters. This is a symptom of Python's file-handling functionality, specifically its tendency to interpret all files opened using `open(filename, mode)` as ASCII. This means that, as Japanese characters can only be encoded in Unicode (UTF-8/16), when the open() function reads a file with Unicode characters, it reads the Unicode characters, tries to interpret them as ASCII and vomits out gibberish (specifically a backslash followed by a number). To solve this problem, one can use the `open` function from the `codecs` library (`codecs.open(filename, mode, encoding)`) which will open a file with the specified encoding and avoid backslash-number gibberish. Thus, for each of the Python scripts in the repository, I have added `import codecs` to the top and changed each `open(filename, mode)` to `codecs.open(filename, mode)` so solving the problem.