### PR TITLE
Refactored python2 to python3

### DIFF
--- a/js2js.py
+++ b/js2js.py
@@ -32,7 +32,7 @@ def mine_js_file(js_pathname, po_filename):
 
     # Mine strings for l23n from js files.
     js_files = glob.glob(os.path.join(js_pathname, 'js', '*js'))
-    print js_files
+    print(js_files)
 
     for path in js_files:
         basename = os.path.basename(path)
@@ -87,7 +87,7 @@ def mine_js_file(js_pathname, po_filename):
         output.close()
 
     json_files = glob.glob(os.path.join(js_pathname, 'plugins', '*json'))
-    print json_files
+    print(json_files)
 
     for path in json_files:
         basename = os.path.basename(path)
@@ -98,10 +98,10 @@ def mine_js_file(js_pathname, po_filename):
         for line in js_fd:
             tmp = line.split("_('")
             if len(tmp) > 1:
-                print tmp
+                print(tmp)
                 trans_line = tmp[0];
                 for i in range(len(tmp)):
-                    print i
+                    print(i)
                     if i == 0:
                         continue;
                     trans_line += "_('"
@@ -110,10 +110,10 @@ def mine_js_file(js_pathname, po_filename):
                         if j == 0:
                             if tmp2[j] in po_dict:
                                 trans_line += po_dict[tmp2[j]]
-                                print po_dict[tmp2[j]]
+                                print(po_dict[tmp2[j]])
                             else:
                                 trans_line += tmp2[j]
-                                print tmp2[j]
+                                print(tmp2[j])
                         else:
                             trans_line += tmp2[j]
                         if j < len(tmp2) - 1:
@@ -122,10 +122,10 @@ def mine_js_file(js_pathname, po_filename):
 
             tmp = line.split('_("')
             if len(tmp) > 1:
-                print tmp
+                print(tmp)
                 trans_line = tmp[0];
                 for i in range(len(tmp)):
-                    print i
+                    print(i)
                     if i == 0:
                         continue;
                     trans_line += '_("'
@@ -134,10 +134,10 @@ def mine_js_file(js_pathname, po_filename):
                         if j == 0:
                             if tmp2[j] in po_dict:
                                 trans_line += po_dict[tmp2[j]]
-                                print po_dict[tmp2[j]]
+                                print(po_dict[tmp2[j]])
                             else:
                                 trans_line += tmp2[j]
-                                print tmp2[j]
+                                print(tmp2[j])
                         else:
                             trans_line += tmp2[j]
                         if j < len(tmp2) - 1:
@@ -152,6 +152,6 @@ def mine_js_file(js_pathname, po_filename):
     
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print 'js2js.py js-path po-file'
+        print('js2js.py js-path po-file')
     else:
         ini = mine_js_file(sys.argv[1], sys.argv[2])

--- a/js2pot.py
+++ b/js2pot.py
@@ -168,7 +168,7 @@ def mine_js_files(js_pathname, pot_filename):
         if len(new_phrase) > 0:
             output.write('msgid "%s"\nmsgstr ""\n\n' % (new_phrase))
         else:
-            output_write('\n')
+            output.write('\n')
 
     for i in range(len(pot_list)):
         if pot_list[i] in js_list:

--- a/po2po.py
+++ b/po2po.py
@@ -41,14 +41,14 @@ def mine_from_po_to_po(oldfilename, newfilename, ignore_case):
 
         if ignore_case:
             if msgstr_flag and value == '' and  key.lower() in olddict:
-                print 'found a match for %s' % (key)
+                print('found a match for %s' % (key))
                 output.write('msgstr "%s"\n' % (olddict[key.lower()]))
             else:
                 output.write(line);
         else:
             if msgstr_flag and value == '' and  key in olddict:
                 output.write('msgstr "%s"\n' % (olddict[key]))
-                print 'found a match for %s' % (key)
+                print('found a match for %s' % (key))
             else:
                 output.write(line);
 
@@ -57,10 +57,10 @@ def mine_from_po_to_po(oldfilename, newfilename, ignore_case):
 
 if __name__ == '__main__':
     if len(sys.argv) < 3:
-        print "po2po source target [ignorecase]"
+        print("po2po source target [ignorecase]")
     elif len(sys.argv) == 4:
         ini = mine_from_po_to_po(sys.argv[1], sys.argv[2], True)
-        print "Finished"
+        print("Finished")
     else:
         ini = mine_from_po_to_po(sys.argv[1], sys.argv[2], False)
-        print "Finished"
+        print("Finished")


### PR DESCRIPTION
This PR includes several changes across multiple files to update print statements to use the Python 3 `print()` function. Additionally, there is a fix for a typo in a method call.

Updates to print statements for Python 3 compatibility:

* [`js2js.py`](diffhunk://#diff-740912f0acbcb7edc1a9c513008a7b3f3905414a201db6a5a50e6b8c77cebbccL35-R35): Updated all `print` statements to use the `print()` function. [[1]](diffhunk://#diff-740912f0acbcb7edc1a9c513008a7b3f3905414a201db6a5a50e6b8c77cebbccL35-R35) [[2]](diffhunk://#diff-740912f0acbcb7edc1a9c513008a7b3f3905414a201db6a5a50e6b8c77cebbccL90-R90) [[3]](diffhunk://#diff-740912f0acbcb7edc1a9c513008a7b3f3905414a201db6a5a50e6b8c77cebbccL101-R104) [[4]](diffhunk://#diff-740912f0acbcb7edc1a9c513008a7b3f3905414a201db6a5a50e6b8c77cebbccL113-R116) [[5]](diffhunk://#diff-740912f0acbcb7edc1a9c513008a7b3f3905414a201db6a5a50e6b8c77cebbccL125-R128) [[6]](diffhunk://#diff-740912f0acbcb7edc1a9c513008a7b3f3905414a201db6a5a50e6b8c77cebbccL137-R140) [[7]](diffhunk://#diff-740912f0acbcb7edc1a9c513008a7b3f3905414a201db6a5a50e6b8c77cebbccL155-R155)
* [`po2po.py`](diffhunk://#diff-b8f8e15aab9bc1f1c6326fdbfa09a0cd59bb4b2d56965e6a3cee0c143df74bcdL44-R51): Updated all `print` statements to use the `print()` function. [[1]](diffhunk://#diff-b8f8e15aab9bc1f1c6326fdbfa09a0cd59bb4b2d56965e6a3cee0c143df74bcdL44-R51) [[2]](diffhunk://#diff-b8f8e15aab9bc1f1c6326fdbfa09a0cd59bb4b2d56965e6a3cee0c143df74bcdL60-R66)

Bug fix:

* [`js2pot.py`](diffhunk://#diff-a0c2d448be14295b00cb13db433be4bc8d905b24f399d5bd7996b3f0051837ddL171-R171): Fixed a typo in the method call from `output_write` to `output.write`.